### PR TITLE
Added explicit backup file permission

### DIFF
--- a/recipes/mysql-full-backup.sh
+++ b/recipes/mysql-full-backup.sh
@@ -12,6 +12,7 @@ LOG_FILE="$BACKUP_DIRECTORY/"backup_log_"$(date +'%Y_%m')".log
 
 echo "mysqldump started at $(date +'%d-%m-%Y %H:%M:%S')" >> "$LOG_FILE"
 mysqldump -u $DB_USER -p$DB_PASS --quick --single-transaction --flush-logs --all-databases > $BACKUP_FILE | >> $LOG_FILE
+chmod 600 $BACKUP_FILE
 echo "mysqldump finished at $(date +'%d-%m-%Y %H:%M:%S')" >> "$LOG_FILE"
 find "$BACKUP_DIRECTORY" -name 'all_db_backup_*' -mtime +8 -exec rm {} \;
 echo "old files deleted" >> "$LOG_FILE"


### PR DESCRIPTION
Default permissions for the backup files are `664` which is bad as there is often volatile information stored in the database. The only user that should be able to read and write is `forge` in the default configuration. Maybe write permission isn't even necessary.